### PR TITLE
Add Domiciliary Care Home page

### DIFF
--- a/app/domiciliary-care-home/page.js
+++ b/app/domiciliary-care-home/page.js
@@ -1,12 +1,11 @@
 import config from "@config/config.json";
 import SeoMeta from "@layouts/SeoMeta";
-import HomeBanner from "@layouts/partials/HomeBanner";
 import Services from "@layouts/partials/Services";
-import HomeFeatures from "@layouts/partials/HomeFeatures";
-import CareInfoBanner from "@layouts/partials/CareInfoBanner";
 import Contact from "@layouts/Contact";
 import { getListPage, getRegularPage } from "../lib/contentParser";
-import banner from "@/content/home/banner.json";
+import DomiciliaryBanner from "@layouts/domiciliary-care-home/Banner";
+import DomiciliaryPerks from "@layouts/domiciliary-care-home/Perks";
+import StaffingApart from "@layouts/domiciliary-care-home/StaffingApart";
 
 const DomiciliaryCareHome = async () => {
   const homePage = await getListPage("content/_index.md");
@@ -18,15 +17,10 @@ const DomiciliaryCareHome = async () => {
   return (
     <>
       <SeoMeta title={`Domiciliary Care Home | ${title}`} />
-      <HomeBanner banner={banner} />
+      <DomiciliaryBanner />
       <Services services={services} />
-      <HomeFeatures feature={feature} />
-      <CareInfoBanner
-        title="What Sets Our Staffing Apart"
-        description="Our dedicated professionals deliver compassionate support tailored to each individual's needs."
-        imageSrc="/images/banner-caregiving/care-help-2.jpg"
-        primaryButton={{ text: "KNOW MORE", href: "/contact" }}
-      />
+      <DomiciliaryPerks feature={feature} />
+      <StaffingApart />
       <Contact data={contactPage} />
     </>
   );

--- a/app/domiciliary-care-home/page.js
+++ b/app/domiciliary-care-home/page.js
@@ -1,0 +1,35 @@
+import config from "@config/config.json";
+import SeoMeta from "@layouts/SeoMeta";
+import HomeBanner from "@layouts/partials/HomeBanner";
+import Services from "@layouts/partials/Services";
+import HomeFeatures from "@layouts/partials/HomeFeatures";
+import CareInfoBanner from "@layouts/partials/CareInfoBanner";
+import Contact from "@layouts/Contact";
+import { getListPage, getRegularPage } from "../lib/contentParser";
+import banner from "@/content/home/banner.json";
+
+const DomiciliaryCareHome = async () => {
+  const homePage = await getListPage("content/_index.md");
+  const { frontmatter } = homePage;
+  const { feature, services } = frontmatter;
+  const contactPage = await getRegularPage("contact");
+  const { title } = config.site;
+
+  return (
+    <>
+      <SeoMeta title={`Domiciliary Care Home | ${title}`} />
+      <HomeBanner banner={banner} />
+      <Services services={services} />
+      <HomeFeatures feature={feature} />
+      <CareInfoBanner
+        title="What Sets Our Staffing Apart"
+        description="Our dedicated professionals deliver compassionate support tailored to each individual's needs."
+        imageSrc="/images/banner-caregiving/care-help-2.jpg"
+        primaryButton={{ text: "KNOW MORE", href: "/contact" }}
+      />
+      <Contact data={contactPage} />
+    </>
+  );
+};
+
+export default DomiciliaryCareHome;

--- a/layouts/domiciliary-care-home/Banner.js
+++ b/layouts/domiciliary-care-home/Banner.js
@@ -1,0 +1,49 @@
+"use client";
+
+import { markdownify } from "@lib/utils/textConverter";
+import Image from "next/image";
+import Link from "next/link";
+
+// Custom banner for Domiciliary Care Home page
+const DomiciliaryBanner = () => {
+  return (
+    <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] overflow-hidden">
+      <div className="absolute top-0 left-0 w-full h-full z-0 bg-gradient-to-r from-[#2e103d]/40 via-transparent to-transparent pointer-events-none" />
+
+      <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-32 flex flex-col-reverse lg:flex-row items-center justify-between relative z-20 gap-12">
+        {/* Left Content */}
+        <div className="w-full lg:w-1/2 text-left animate-fadeLeftSlow">
+          <h1 className="text-4xl md:text-5xl font-extrabold bg-clip-text text-transparent" style={{ backgroundImage: "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)" }}>
+            Domiciliary Care Home
+          </h1>
+          <p className="mt-4 text-white text-lg max-w-xl">
+            {markdownify("Professional home care services tailored for your comfort and independence.")}
+          </p>
+          <div className="mt-6 flex gap-4">
+            <Link href="/domiciliary" className="inline-block border-2 border-white text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-white hover:text-accent transition">
+              Services
+            </Link>
+            <Link href="/contact" className="inline-block border-2 border-white text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-white hover:text-accent transition">
+              Know More
+            </Link>
+          </div>
+        </div>
+
+        {/* Right Image */}
+        <div className="w-full max-w-[680px] h-auto">
+          <div className="aspect-video h-full rounded-2xl shadow-xl overflow-hidden border border-gray-200 bg-white">
+            <Image src="/images/banner-caregiving/hero1.jpg" alt="Domiciliary banner" width={900} height={720} className="w-full h-full object-cover" />
+          </div>
+        </div>
+      </div>
+
+      <div className="absolute bottom-0 left-0 right-0 z-10">
+        <svg viewBox="0 0 1440 120" className="w-full h-[100px] lg:h-[160px] transform scale-x-[-1]" preserveAspectRatio="none">
+          <path fill="#431c52" d="M0,32L60,48C120,64,240,96,360,96C480,96,600,64,720,64C840,64,960,96,1080,106.7C1200,117,1320,107,1380,101.3L1440,96L1440,120L1380,120C1320,120,1200,120,1080,120C960,120,840,120,720,120C600,120,480,120,360,120C240,120,120,120,60,120L0,120Z"></path>
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default DomiciliaryBanner;

--- a/layouts/domiciliary-care-home/Perks.js
+++ b/layouts/domiciliary-care-home/Perks.js
@@ -1,0 +1,7 @@
+import HomeFeatures from "@layouts/partials/HomeFeatures";
+
+const DomiciliaryPerks = ({ feature }) => {
+  return <HomeFeatures feature={feature} />;
+};
+
+export default DomiciliaryPerks;

--- a/layouts/domiciliary-care-home/StaffingApart.js
+++ b/layouts/domiciliary-care-home/StaffingApart.js
@@ -1,0 +1,14 @@
+import CareInfoBanner from "@layouts/partials/CareInfoBanner";
+
+const StaffingApart = () => {
+  return (
+    <CareInfoBanner
+      title="What Sets Our Staffing Apart"
+      description="Our dedicated professionals deliver compassionate support tailored to each individual's needs."
+      imageSrc="/images/banner-caregiving/care-help-2.jpg"
+      primaryButton={{ text: "KNOW MORE", href: "/contact" }}
+    />
+  );
+};
+
+export default StaffingApart;


### PR DESCRIPTION
## Summary
- add a `domiciliary-care-home` route
- reuse home page sections to showcase services, perks and contact form

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686518f3e68c8333ab117ce7f905e6df