### PR TITLE
Add new How We Work page with components

### DIFF
--- a/app/how-we-work/page.js
+++ b/app/how-we-work/page.js
@@ -1,0 +1,26 @@
+import config from "@config/config.json";
+import SeoMeta from "@layouts/SeoMeta";
+import { getRegularPage } from "@lib/contentParser";
+import HowWeWorkBanner from "@layouts/how-we-work/Banner";
+import WorkSteps from "@layouts/how-we-work/WorkSteps";
+import HelpCards from "@layouts/how-we-work/HelpCards";
+import ContactFormSection from "@layouts/how-we-work/ContactFormSection";
+import ContactUsBanner from "@layouts/how-we-work/ContactUsBanner";
+
+const HowWeWorkPage = async () => {
+  const contactPage = await getRegularPage("contact");
+  const { title } = config.site;
+
+  return (
+    <>
+      <SeoMeta title={`How We Work | ${title}`} />
+      <HowWeWorkBanner />
+      <WorkSteps />
+      <HelpCards />
+      <ContactFormSection data={contactPage} />
+      <ContactUsBanner />
+    </>
+  );
+};
+
+export default HowWeWorkPage;

--- a/layouts/how-we-work/Banner.js
+++ b/layouts/how-we-work/Banner.js
@@ -1,0 +1,37 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+const HowWeWorkBanner = () => {
+  return (
+    <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] overflow-hidden">
+      <div className="absolute top-0 left-0 w-full h-full z-0 bg-gradient-to-r from-[#2e103d]/40 via-transparent to-transparent pointer-events-none" />
+      <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-32 flex flex-col-reverse lg:flex-row items-center justify-between relative z-20 gap-12">
+        <div className="w-full lg:w-1/2 text-left animate-fadeLeftSlow">
+          <h1 className="text-4xl md:text-5xl font-extrabold bg-clip-text text-transparent" style={{ backgroundImage: "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)" }}>
+            How We Work
+          </h1>
+          <p className="mt-4 text-white text-lg max-w-xl">
+            We follow a simple process to match you with the right carers and ensure quality support at every step.
+          </p>
+          <Link href="/contact" className="inline-block mt-6 border-2 border-white text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-white hover:text-accent transition">
+            Get Started
+          </Link>
+        </div>
+        <div className="w-full max-w-[680px] h-auto">
+          <div className="aspect-video h-full rounded-2xl shadow-xl overflow-hidden border border-gray-200 bg-white">
+            <Image src="/images/banner-caregiving/hero2.jpg" alt="How we work" width={900} height={720} className="w-full h-full object-cover" />
+          </div>
+        </div>
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 z-10">
+        <svg viewBox="0 0 1440 120" className="w-full h-[100px] lg:h-[160px] transform scale-x-[-1]" preserveAspectRatio="none">
+          <path fill="#431c52" d="M0,32L60,48C120,64,240,96,360,96C480,96,600,64,720,64C840,64,960,96,1080,106.7C1200,117,1320,107,1380,101.3L1440,96L1440,120L1380,120C1320,120,1200,120,1080,120C960,120,840,120,720,120C600,120,480,120,360,120C240,120,120,120,60,120L0,120Z" />
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default HowWeWorkBanner;

--- a/layouts/how-we-work/ContactFormSection.js
+++ b/layouts/how-we-work/ContactFormSection.js
@@ -1,0 +1,78 @@
+import config from "@config/config.json";
+import { markdownify } from "@lib/utils/textConverter";
+import Image from "next/image";
+
+const ContactFormSection = ({ data }) => {
+  const { frontmatter } = data;
+  const { title, info } = frontmatter;
+  const { contact_form_action } = config.params;
+
+  return (
+    <section className="section bg-[#F9F7FB]">
+      <div className="container">
+        {markdownify(title, "h2", "text-center font-normal mb-8")}
+        <div className="grid md:grid-cols-2 gap-10 items-center">
+          <div>
+            <form
+              className="space-y-4"
+              method="POST"
+              action={contact_form_action}
+            >
+              <input
+                className="form-input w-full rounded"
+                name="name"
+                type="text"
+                placeholder="Name"
+                required
+              />
+              <input
+                className="form-input w-full rounded"
+                name="email"
+                type="email"
+                placeholder="Your email"
+                required
+              />
+              <input
+                className="form-input w-full rounded"
+                name="subject"
+                type="text"
+                placeholder="Subject"
+                required
+              />
+              <textarea
+                className="form-textarea w-full rounded-md"
+                rows="5"
+                placeholder="Your message"
+              />
+              <button type="submit" className="btn btn-primary w-full">
+                Send Now
+              </button>
+            </form>
+          </div>
+          <div className="text-center">
+            <Image
+              src="/images/banner-caregiving/care-help-2.jpg"
+              alt="Contact"
+              width={600}
+              height={450}
+              className="rounded-xl border"
+            />
+            <div className="mt-6 text-left">
+              {markdownify(info.title, "h4", "text-[#2f2f85]")}
+              {markdownify(info.description, "p", "mt-2 text-gray-700")}
+              <ul className="mt-4 space-y-1">
+                {info.contacts.map((contact, index) => (
+                  <li key={index} className="text-sm text-gray-800">
+                    {markdownify(contact, "strong", "text-dark")}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ContactFormSection;

--- a/layouts/how-we-work/ContactUsBanner.js
+++ b/layouts/how-we-work/ContactUsBanner.js
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+const ContactUsBanner = () => {
+  return (
+    <section className="py-12 bg-gradient-to-r from-[#431c52] via-[#6a2c70] to-[#f4b860] text-center text-white">
+      <h2 className="text-2xl md:text-3xl font-semibold mb-4">Ready to Begin?</h2>
+      <p className="mb-6 max-w-xl mx-auto">
+        Reach out to our friendly team today to discuss how we can support you or your loved ones.
+      </p>
+      <Link
+        href="/contact"
+        className="inline-block bg-white text-[#431c52] font-semibold px-6 py-3 rounded-full shadow hover:opacity-90 transition"
+      >
+        Contact Us
+      </Link>
+    </section>
+  );
+};
+
+export default ContactUsBanner;

--- a/layouts/how-we-work/HelpCards.js
+++ b/layouts/how-we-work/HelpCards.js
@@ -1,0 +1,51 @@
+const helps = [
+  {
+    title: "Experienced Professionals",
+    description: "Our carers are trained and vetted, giving you peace of mind.",
+    icon: "user",
+  },
+  {
+    title: "Tailored Services",
+    description: "Flexible options ensure the right level of care for every situation.",
+    icon: "cog",
+  },
+  {
+    title: "24/7 Availability",
+    description: "Support whenever you need it, day or night.",
+    icon: "clock",
+  },
+];
+
+import { MdPerson, MdBuild, MdAccessTime } from "react-icons/md";
+
+const iconMap = {
+  user: <MdPerson size={30} className="text-brand" />,
+  cog: <MdBuild size={30} className="text-brand" />,
+  clock: <MdAccessTime size={30} className="text-brand" />,
+};
+
+const HelpCards = () => {
+  return (
+    <section className="py-16">
+      <div className="container px-4 mx-auto">
+        <h2 className="text-3xl font-bold text-center text-[#2f2f85] mb-12">How We Help</h2>
+        <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {helps.map((item, index) => (
+            <div
+              key={index}
+              className="bg-white border border-[#e5e5f7] rounded-xl text-center p-8 shadow-md hover:shadow-lg hover:scale-[1.015] transition duration-300"
+            >
+              <div className="w-16 h-16 mx-auto flex items-center justify-center bg-[#e8eafd] rounded-full mb-5">
+                {iconMap[item.icon]}
+              </div>
+              <h3 className="text-lg font-semibold text-[#2f2f85]">{item.title}</h3>
+              <p className="mt-3 text-gray-600 text-sm leading-relaxed">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default HelpCards;

--- a/layouts/how-we-work/WorkSteps.js
+++ b/layouts/how-we-work/WorkSteps.js
@@ -1,0 +1,48 @@
+const steps = [
+  {
+    title: "Initial Consultation",
+    description:
+      "We discuss your needs and preferences to understand the level of support required.",
+  },
+  {
+    title: "Care Plan Proposal",
+    description:
+      "Our team designs a personalised care plan outlining recommended services and schedules.",
+  },
+  {
+    title: "Caregiver Matching",
+    description:
+      "We match you with experienced carers best suited to your situation and lifestyle.",
+  },
+  {
+    title: "Ongoing Support",
+    description:
+      "Regular check-ins and feedback ensure the care provided remains flexible and effective.",
+  },
+];
+
+const WorkSteps = () => {
+  return (
+    <section className="py-16 bg-[#F9F7FB]">
+      <div className="container px-4 mx-auto">
+        <h2 className="text-3xl font-bold text-center text-[#2f2f85] mb-12">Our Process</h2>
+        <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-4">
+          {steps.map((step, index) => (
+            <div
+              key={index}
+              className="bg-white border border-[#e5e5f7] rounded-xl p-6 text-center shadow-md hover:shadow-lg transition"
+            >
+              <div className="w-12 h-12 mx-auto mb-4 text-lg font-bold flex items-center justify-center rounded-full bg-[#e8eafd] text-[#5e3ea1]">
+                {index + 1}
+              </div>
+              <h3 className="font-semibold text-[#2f2f85] mb-2">{step.title}</h3>
+              <p className="text-sm text-gray-600 leading-relaxed">{step.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default WorkSteps;


### PR DESCRIPTION
## Summary
- create How We Work page
- add reusable banner, work steps, help cards, contact form section and contact banner components

## Testing
- `npm run lint`
- `npm run build` *(fails: could not fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_686961ae84888333a0a1d9b70399a418