### PR TITLE
Add staffing service page

### DIFF
--- a/app/staffing/page.js
+++ b/app/staffing/page.js
@@ -1,0 +1,17 @@
+import StaffingBanner from "@layouts/staffing/Banner";
+import StaffingOptions from "@layouts/staffing/Options";
+import ServiceScopes from "@layouts/staffing/Scopes";
+import ServiceDescription from "@layouts/staffing/Description";
+
+const StaffingPage = () => {
+  return (
+    <>
+      <StaffingBanner />
+      <StaffingOptions />
+      <ServiceScopes />
+      <ServiceDescription />
+    </>
+  );
+};
+
+export default StaffingPage;

--- a/config/menu.json
+++ b/config/menu.json
@@ -4,12 +4,16 @@
       "name": "Home",
       "url": "/"
     },
-    {
-      "name": "Domiciliary Services",
-      "url": "/domiciliary"
-    },
-    {
-      "name": "Blog",
+      {
+        "name": "Domiciliary Services",
+        "url": "/domiciliary"
+      },
+      {
+        "name": "Staffing",
+        "url": "/staffing"
+      },
+      {
+        "name": "Blog",
       "url": "/blogs"
     },
     {

--- a/layouts/staffing/Banner.js
+++ b/layouts/staffing/Banner.js
@@ -1,0 +1,71 @@
+"use client";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+import SwiperCore, { Autoplay, Pagination } from "swiper";
+import "swiper/css";
+import "swiper/css/pagination";
+import Image from "next/image";
+
+SwiperCore.use([Autoplay, Pagination]);
+
+const slides = [
+  {
+    title: "Expert Healthcare Staffing",
+    text: "Connecting you with qualified professionals when you need them most.",
+  },
+  {
+    title: "Rapid Placement Solutions",
+    text: "Our network allows quick response for urgent staffing requirements.",
+  },
+  {
+    title: "24/7 Support",
+    text: "We are available around the clock to assist your organisation.",
+  },
+];
+
+const StaffingBanner = () => {
+  return (
+    <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] overflow-hidden">
+      <div className="absolute top-0 left-0 w-full h-full z-0 bg-gradient-to-r from-[#2e103d]/40 via-transparent to-transparent pointer-events-none" />
+      <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-32 flex flex-col-reverse lg:flex-row items-center justify-between relative z-20 gap-12">
+        {/* Left Text Carousel */}
+        <div className="w-full lg:w-1/2 animate-fadeLeftSlow">
+          <Swiper
+            modules={[Autoplay, Pagination]}
+            autoplay={{ delay: 4000, disableOnInteraction: false }}
+            pagination={{ clickable: true }}
+            loop
+          >
+            {slides.map((slide, i) => (
+              <SwiperSlide key={i} className="text-white py-4">
+                <h1 className="text-4xl md:text-5xl font-extrabold mb-4 bg-clip-text text-transparent" style={{backgroundImage:"linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)"}}>
+                  {slide.title}
+                </h1>
+                <p className="text-lg max-w-xl">{slide.text}</p>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </div>
+        {/* Right Image */}
+        <div className="w-full max-w-[680px] h-auto">
+          <div className="aspect-video h-full rounded-2xl shadow-xl overflow-hidden border border-gray-200 bg-white">
+            <Image
+              src="/images/banner-caregiving/hero2.jpg"
+              alt="Staffing banner"
+              width={900}
+              height={720}
+              className="w-full h-full object-cover"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 z-10">
+        <svg viewBox="0 0 1440 120" className="w-full h-[100px] lg:h-[160px] transform scale-x-[-1]" preserveAspectRatio="none">
+          <path fill="#431c52" d="M0,32L60,48C120,64,240,96,360,96C480,96,600,64,720,64C840,64,960,96,1080,106.7C1200,117,1320,107,1380,101.3L1440,96L1440,120L1380,120C1320,120,1200,120,1080,120C960,120,840,120,720,120C600,120,480,120,360,120C240,120,120,120,60,120L0,120Z" />
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default StaffingBanner;

--- a/layouts/staffing/Description.js
+++ b/layouts/staffing/Description.js
@@ -1,0 +1,39 @@
+"use client";
+
+import Image from "next/image";
+
+const ServiceDescription = ({
+  title = "Why Choose Our Staffing Services", // default text
+  description = "Our dedicated team connects healthcare providers with experienced professionals who deliver compassionate care.",
+  points = [
+    "Thorough vetting and compliance checks",
+    "Flexible contracts to suit your needs",
+    "Friendly support team available 24/7",
+  ],
+  imageSrc = "/images/banner-caregiving/care-help-2.jpg",
+}) => (
+  <section className="py-16 bg-theme-light">
+    <div className="container grid md:grid-cols-2 gap-8 items-center">
+      <div className="order-2 md:order-1">
+        <Image
+          src={imageSrc}
+          alt={title}
+          width={600}
+          height={400}
+          className="rounded-xl w-full h-auto object-cover border"
+        />
+      </div>
+      <div className="order-1 md:order-2">
+        <h2 className="text-3xl font-bold text-primary mb-4">{title}</h2>
+        <p className="text-gray-700 mb-4">{description}</p>
+        <ul className="list-disc pl-5 space-y-1 text-gray-700 text-sm">
+          {points.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceDescription;

--- a/layouts/staffing/Options.js
+++ b/layouts/staffing/Options.js
@@ -1,0 +1,47 @@
+"use client";
+
+import { MdSchedule, MdGroup, MdPerson } from "react-icons/md";
+
+const options = [
+  {
+    icon: <MdSchedule size={40} className="text-accent" />,
+    title: "Temporary Staffing",
+    text: "Qualified professionals available for short-term cover and urgent needs.",
+  },
+  {
+    icon: <MdPerson size={40} className="text-accent" />,
+    title: "Permanent Placement",
+    text: "Find the right carers and nurses to join your team long term.",
+  },
+  {
+    icon: <MdGroup size={40} className="text-accent" />,
+    title: "Home Care Staffing",
+    text: "Compassionate carers to support clients within their own homes.",
+  },
+];
+
+const StaffingOptions = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">
+        Staffing Options
+      </h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {options.map((item, i) => (
+          <div
+            key={i}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow hover:shadow-lg transition"
+          >
+            <div className="mb-4 flex justify-center">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">
+              {item.title}
+            </h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default StaffingOptions;

--- a/layouts/staffing/Scopes.js
+++ b/layouts/staffing/Scopes.js
@@ -1,0 +1,45 @@
+"use client";
+
+import { MdLocalHospital, MdHomeWork, MdElderly } from "react-icons/md";
+
+const scopes = [
+  {
+    icon: <MdLocalHospital size={40} className="text-accent" />,
+    title: "Hospitals & Clinics",
+    text: "Reliable staff to maintain high standards of patient care.",
+  },
+  {
+    icon: <MdHomeWork size={40} className="text-accent" />,
+    title: "Care Homes",
+    text: "Supportive carers and nurses for residential settings.",
+  },
+  {
+    icon: <MdElderly size={40} className="text-accent" />,
+    title: "Community & Home Care",
+    text: "Experienced caregivers helping clients remain independent.",
+  },
+];
+
+const ServiceScopes = () => (
+  <section className="py-16">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">
+        Service Scopes
+      </h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {scopes.map((item, i) => (
+          <div
+            key={i}
+            className="border border-gray-200 rounded-xl p-6 text-center bg-white shadow hover:shadow-lg transition"
+          >
+            <div className="flex justify-center mb-4">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{item.title}</h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceScopes;


### PR DESCRIPTION
## Summary
- implement `Staffing` page with banner carousel and sections
- add new partial components for staffing
- update site menu to link to `/staffing`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6869626442d48333a728e6f48aec9a3b