### PR TITLE
Add basic menu for home, domiciliary and staffing

### DIFF
--- a/app/domiciliary/page.js
+++ b/app/domiciliary/page.js
@@ -1,5 +1,6 @@
 import config from "@config/config.json";
 
+import SimpleHeader from "@layouts/partials/SimpleHeader";
 import HomeBanner from "@layouts/partials/HomeBanner";
 import HomeFeatures from "@layouts/partials/HomeFeatures";
 import Services from "@layouts/partials/Services";
@@ -15,6 +16,7 @@ const Domiciliary = async () => {
 
   return (
     <>
+      <SimpleHeader />
       {/* Banner */}
       <HomeBanner banner={banner} />
       {/* services */}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,7 +1,4 @@
 import "../styles/style.scss";
-import config from "@config/config.json";
-import theme from "@config/theme.json";
-import SimpleHeader from "@layouts/partials/SimpleHeader";
 import Footer from "@layouts/partials/Footer";
 import Providers from "@layouts/partials/Providers";
 import { Inter, Merriweather, Playfair_Display } from "next/font/google";
@@ -40,7 +37,6 @@ export default function RootLayout({ children }) {
       className={`${inter.variable} ${playfair.variable} ${merriweather.variable}`}
     >
       <body className="font-sans text-brandText antialiased">
-        <SimpleHeader />
         <Providers>{children}</Providers>
         <Footer />
       </body>

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,7 +1,7 @@
 import "../styles/style.scss";
 import config from "@config/config.json";
 import theme from "@config/theme.json";
-import Header from "@layouts/partials/Header";
+import SimpleHeader from "@layouts/partials/SimpleHeader";
 import Footer from "@layouts/partials/Footer";
 import Providers from "@layouts/partials/Providers";
 import { Inter, Merriweather, Playfair_Display } from "next/font/google";
@@ -40,7 +40,7 @@ export default function RootLayout({ children }) {
       className={`${inter.variable} ${playfair.variable} ${merriweather.variable}`}
     >
       <body className="font-sans text-brandText antialiased">
-        <Header />
+        <SimpleHeader />
         <Providers>{children}</Providers>
         <Footer />
       </body>

--- a/app/page.js
+++ b/app/page.js
@@ -2,6 +2,7 @@ import config from "@config/config.json";
 import Cta from "@layouts/components/Cta";
 import SeoMeta from "@layouts/SeoMeta";
 
+import SimpleHeader from "@layouts/partials/SimpleHeader";
 import HomeBanner from "@layouts/partials/HomeBanner";
 import HomeFeatures from "@layouts/partials/HomeFeatures";
 import Services from "@layouts/partials/Services";
@@ -18,6 +19,7 @@ const Home = async () => {
   return (
     <>
       <SeoMeta title={title} />
+      <SimpleHeader />
       {/* Banner */}
       <HomeBanner banner={banner} />
       {/* services */}

--- a/app/staffing/page.js
+++ b/app/staffing/page.js
@@ -1,3 +1,4 @@
+import SimpleHeader from "@layouts/partials/SimpleHeader";
 import StaffingBanner from "@layouts/staffing/Banner";
 import StaffingOptions from "@layouts/staffing/Options";
 import ServiceScopes from "@layouts/staffing/Scopes";
@@ -6,6 +7,7 @@ import ServiceDescription from "@layouts/staffing/Description";
 const StaffingPage = () => {
   return (
     <>
+      <SimpleHeader />
       <StaffingBanner />
       <StaffingOptions />
       <ServiceScopes />

--- a/config/menu.json
+++ b/config/menu.json
@@ -11,23 +11,7 @@
       {
         "name": "Staffing",
         "url": "/staffing"
-      },
-      {
-        "name": "Blog",
-      "url": "/blogs"
-    },
-    {
-      "name": "Pricing",
-      "url": "/pricing"
-    },
-    {
-      "name": "Contact",
-      "url": "/contact"
-    },
-    {
-      "name": "FAQ",
-      "url": "/faq"
-    }
+      }
   ],
   "footer": [
     {

--- a/layouts/partials/SimpleHeader.js
+++ b/layouts/partials/SimpleHeader.js
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { usePathname } from "next/navigation";
+import config from "@config/config.json";
+import menu from "@config/menu.json";
+
+const SimpleHeader = () => {
+  const pathname = usePathname();
+  const { main } = menu;
+  const { base_url, logo, title } = config.site;
+
+  return (
+    <header className="bg-white shadow">
+      <div className="max-w-7xl mx-auto px-4 md:px-8">
+        <div className="flex items-center justify-between py-4">
+          <Link href={base_url} className="flex items-center">
+            <Image
+              src={logo}
+              alt={title}
+              width={180}
+              height={100}
+              className="object-contain max-h-[70px] w-auto"
+              priority
+            />
+          </Link>
+          <nav>
+            <ul className="flex space-x-6 font-semibold text-accent uppercase">
+              {main.map((item, i) => (
+                <li key={i}>
+                  <Link
+                    href={item.url}
+                    className={`px-4 py-2 rounded-full transition-colors duration-200 ${
+                      pathname === item.url ? "bg-primary text-white" : "hover:text-primary"
+                    }`}
+                  >
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default SimpleHeader;


### PR DESCRIPTION
## Summary
- create `SimpleHeader` component with a 3‑item menu
- swap in `SimpleHeader` for the root layout
- trim `config/menu.json` so the main menu only lists Home, Domiciliary and Staffing

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6869653d881483339d1f844fe7c581f5