### PR TITLE
Add dedicated layouts for staffing and domiciliary

### DIFF
--- a/app/domiciliary/about-us/page.js
+++ b/app/domiciliary/about-us/page.js
@@ -1,0 +1,8 @@
+const AboutUs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">About Us</h1>
+    <p>Information about our domiciliary services.</p>
+  </section>
+);
+
+export default AboutUs;

--- a/app/domiciliary/available-jobs/page.js
+++ b/app/domiciliary/available-jobs/page.js
@@ -1,0 +1,8 @@
+const AvailableJobs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Available Jobs</h1>
+    <p>Current job openings within our domiciliary team.</p>
+  </section>
+);
+
+export default AvailableJobs;

--- a/app/domiciliary/care-services/page.js
+++ b/app/domiciliary/care-services/page.js
@@ -1,0 +1,8 @@
+const CareServices = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Care Services</h1>
+    <p>Overview of the care services we provide.</p>
+  </section>
+);
+
+export default CareServices;

--- a/app/domiciliary/contact-us/page.js
+++ b/app/domiciliary/contact-us/page.js
@@ -1,0 +1,8 @@
+const ContactUs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+    <p>Reach out to our domiciliary care team.</p>
+  </section>
+);
+
+export default ContactUs;

--- a/app/domiciliary/how-we-work/page.js
+++ b/app/domiciliary/how-we-work/page.js
@@ -1,0 +1,8 @@
+const HowWeWork = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">How We Work</h1>
+    <p>Learn about our approach to domiciliary care.</p>
+  </section>
+);
+
+export default HowWeWork;

--- a/app/domiciliary/layout.js
+++ b/app/domiciliary/layout.js
@@ -1,0 +1,11 @@
+import Header from "@layouts/partials/Header";
+import menu from "@config/menu-domiciliary.json";
+
+export default function DomiciliaryLayout({ children }) {
+  return (
+    <>
+      <Header menuItems={menu.main} />
+      {children}
+    </>
+  );
+}

--- a/app/domiciliary/page.js
+++ b/app/domiciliary/page.js
@@ -1,6 +1,5 @@
 import config from "@config/config.json";
 
-import SimpleHeader from "@layouts/partials/SimpleHeader";
 import HomeBanner from "@layouts/partials/HomeBanner";
 import HomeFeatures from "@layouts/partials/HomeFeatures";
 import Services from "@layouts/partials/Services";
@@ -16,7 +15,6 @@ const Domiciliary = async () => {
 
   return (
     <>
-      <SimpleHeader />
       {/* Banner */}
       <HomeBanner banner={banner} />
       {/* services */}

--- a/app/staffing/about-us/page.js
+++ b/app/staffing/about-us/page.js
@@ -1,0 +1,8 @@
+const AboutUs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">About Us</h1>
+    <p>Learn about our healthcare staffing solutions.</p>
+  </section>
+);
+
+export default AboutUs;

--- a/app/staffing/available-jobs/page.js
+++ b/app/staffing/available-jobs/page.js
@@ -1,0 +1,8 @@
+const AvailableJobs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Available Jobs</h1>
+    <p>Browse current openings with our clients.</p>
+  </section>
+);
+
+export default AvailableJobs;

--- a/app/staffing/care-services/page.js
+++ b/app/staffing/care-services/page.js
@@ -1,0 +1,8 @@
+const CareServices = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Care Services</h1>
+    <p>Details on the staffing services we provide.</p>
+  </section>
+);
+
+export default CareServices;

--- a/app/staffing/contact-us/page.js
+++ b/app/staffing/contact-us/page.js
@@ -1,0 +1,8 @@
+const ContactUs = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
+    <p>Get in touch regarding staffing services.</p>
+  </section>
+);
+
+export default ContactUs;

--- a/app/staffing/how-we-work/page.js
+++ b/app/staffing/how-we-work/page.js
@@ -1,0 +1,8 @@
+const HowWeWork = () => (
+  <section className="container py-16">
+    <h1 className="text-3xl font-bold mb-4">How We Work</h1>
+    <p>Our process for matching staff with providers.</p>
+  </section>
+);
+
+export default HowWeWork;

--- a/app/staffing/layout.js
+++ b/app/staffing/layout.js
@@ -1,0 +1,11 @@
+import Header from "@layouts/partials/Header";
+import menu from "@config/menu-staffing.json";
+
+export default function StaffingLayout({ children }) {
+  return (
+    <>
+      <Header menuItems={menu.main} />
+      {children}
+    </>
+  );
+}

--- a/app/staffing/page.js
+++ b/app/staffing/page.js
@@ -1,4 +1,3 @@
-import SimpleHeader from "@layouts/partials/SimpleHeader";
 import StaffingBanner from "@layouts/staffing/Banner";
 import StaffingOptions from "@layouts/staffing/Options";
 import ServiceScopes from "@layouts/staffing/Scopes";
@@ -7,7 +6,6 @@ import ServiceDescription from "@layouts/staffing/Description";
 const StaffingPage = () => {
   return (
     <>
-      <SimpleHeader />
       <StaffingBanner />
       <StaffingOptions />
       <ServiceScopes />

--- a/config/menu-domiciliary.json
+++ b/config/menu-domiciliary.json
@@ -1,0 +1,10 @@
+{
+  "main": [
+    { "name": "Home", "url": "/domiciliary" },
+    { "name": "About Us", "url": "/domiciliary/about-us" },
+    { "name": "Care Services", "url": "/domiciliary/care-services" },
+    { "name": "How We Work", "url": "/domiciliary/how-we-work" },
+    { "name": "Available Jobs", "url": "/domiciliary/available-jobs" },
+    { "name": "Contact Us", "url": "/domiciliary/contact-us" }
+  ]
+}

--- a/config/menu-staffing.json
+++ b/config/menu-staffing.json
@@ -1,0 +1,10 @@
+{
+  "main": [
+    { "name": "Home", "url": "/staffing" },
+    { "name": "About Us", "url": "/staffing/about-us" },
+    { "name": "Care Services", "url": "/staffing/care-services" },
+    { "name": "How We Work", "url": "/staffing/how-we-work" },
+    { "name": "Available Jobs", "url": "/staffing/available-jobs" },
+    { "name": "Contact Us", "url": "/staffing/contact-us" }
+  ]
+}

--- a/layouts/partials/Header.js
+++ b/layouts/partials/Header.js
@@ -8,10 +8,10 @@ import { FaFacebookF, FaLinkedinIn, FaPhoneAlt } from "react-icons/fa";
 import config from "@config/config.json";
 import menu from "@config/menu.json";
 
-const Header = () => {
+const Header = ({ menuItems }) => {
   const pathname = usePathname();
   const { base_url, logo, title } = config.site;
-  const { main } = menu;
+  const main = menuItems || menu.main;
   const { enable, label, link } = config.nav_button;
 
   const [navOpen, setNavOpen] = useState(false);


### PR DESCRIPTION
## Summary
- update `Header` to accept optional menu items
- create layouts for the domiciliary and staffing sections
- add menu configuration files for these sections
- add new child pages under each section
- remove SimpleHeader usage from domiciliary and staffing pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68696c15d0148333bb88340f148b60a7