### PR TITLE
Add staffing service pages

### DIFF
--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,0 +1,9 @@
+import Contact from "@layouts/Contact";
+import { getRegularPage } from "@lib/contentParser";
+
+const ContactPage = async () => {
+  const contactPage = await getRegularPage("contact");
+  return <Contact data={contactPage} />;
+};
+
+export default ContactPage;

--- a/app/domiciliary/contact-us/page.js
+++ b/app/domiciliary/contact-us/page.js
@@ -1,8 +1,1 @@
-const ContactUs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
-    <p>Reach out to our domiciliary care team.</p>
-  </section>
-);
-
-export default ContactUs;
+export { default } from "../../contact/page";

--- a/app/staffing/about-us/page.js
+++ b/app/staffing/about-us/page.js
@@ -1,8 +1,13 @@
+import AboutBanner from "@layouts/staffing/About/Banner";
+import MissionValues from "@layouts/staffing/About/MissionValues";
+import TeamShowcase from "@layouts/staffing/About/TeamShowcase";
+
 const AboutUs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">About Us</h1>
-    <p>Learn about our healthcare staffing solutions.</p>
-  </section>
+  <>
+    <AboutBanner />
+    <MissionValues />
+    <TeamShowcase />
+  </>
 );
 
 export default AboutUs;

--- a/app/staffing/available-jobs/page.js
+++ b/app/staffing/available-jobs/page.js
@@ -1,8 +1,11 @@
+import JobsBanner from "@layouts/staffing/JobsBanner";
+import JobList from "@layouts/staffing/JobList";
+
 const AvailableJobs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Available Jobs</h1>
-    <p>Browse current openings with our clients.</p>
-  </section>
+  <>
+    <JobsBanner />
+    <JobList />
+  </>
 );
 
 export default AvailableJobs;

--- a/app/staffing/care-services/page.js
+++ b/app/staffing/care-services/page.js
@@ -1,8 +1,15 @@
+import StaffingBanner from "@layouts/staffing/Banner";
+import StaffingOptions from "@layouts/staffing/Options";
+import ServiceScopes from "@layouts/staffing/Scopes";
+import ServiceDescription from "@layouts/staffing/Description";
+
 const CareServices = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Care Services</h1>
-    <p>Details on the staffing services we provide.</p>
-  </section>
+  <>
+    <StaffingBanner />
+    <StaffingOptions />
+    <ServiceScopes />
+    <ServiceDescription />
+  </>
 );
 
 export default CareServices;

--- a/app/staffing/contact-us/page.js
+++ b/app/staffing/contact-us/page.js
@@ -1,8 +1,1 @@
-const ContactUs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Contact Us</h1>
-    <p>Get in touch regarding staffing services.</p>
-  </section>
-);
-
-export default ContactUs;
+export { default } from "../../contact/page";

--- a/app/staffing/how-we-work/page.js
+++ b/app/staffing/how-we-work/page.js
@@ -1,8 +1,15 @@
+import HowWeWorkBanner from "@layouts/how-we-work/Banner";
+import WorkSteps from "@layouts/how-we-work/WorkSteps";
+import HelpCards from "@layouts/how-we-work/HelpCards";
+import ContactUsBanner from "@layouts/how-we-work/ContactUsBanner";
+
 const HowWeWork = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">How We Work</h1>
-    <p>Our process for matching staff with providers.</p>
-  </section>
+  <>
+    <HowWeWorkBanner />
+    <WorkSteps />
+    <HelpCards />
+    <ContactUsBanner />
+  </>
 );
 
 export default HowWeWork;

--- a/layouts/staffing/About/Banner.js
+++ b/layouts/staffing/About/Banner.js
@@ -1,0 +1,14 @@
+"use client";
+
+const AboutBanner = () => (
+  <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
+    <div className="container py-20 text-center">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">About Us</h1>
+      <p className="max-w-2xl mx-auto text-lg">
+        Dedicated to connecting healthcare organisations with trusted staff across the UK.
+      </p>
+    </div>
+  </section>
+);
+
+export default AboutBanner;

--- a/layouts/staffing/About/MissionValues.js
+++ b/layouts/staffing/About/MissionValues.js
@@ -1,0 +1,33 @@
+"use client";
+
+const MissionValues = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container grid md:grid-cols-2 gap-10 items-center">
+      <div>
+        <h2 className="text-3xl font-bold text-primary mb-4">Our Mission</h2>
+        <p className="text-gray-700 mb-4">
+          We provide reliable and compassionate healthcare professionals wherever they are needed.
+        </p>
+        <p className="text-gray-700">
+          Integrity, respect and quality are at the heart of everything we do.
+        </p>
+      </div>
+      <div className="space-y-4">
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Quality Recruitment</h3>
+          <p className="text-sm text-gray-600">All candidates undergo comprehensive vetting.</p>
+        </div>
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Responsive Support</h3>
+          <p className="text-sm text-gray-600">Our team is available 24/7 for urgent requests.</p>
+        </div>
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Nationwide Cover</h3>
+          <p className="text-sm text-gray-600">We place professionals across the UK.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default MissionValues;

--- a/layouts/staffing/About/TeamShowcase.js
+++ b/layouts/staffing/About/TeamShowcase.js
@@ -1,0 +1,25 @@
+"use client";
+
+const team = [
+  { name: "Jessica Brown", role: "Recruitment Manager" },
+  { name: "Mark Thompson", role: "Compliance Lead" },
+  { name: "Sarah Ahmed", role: "Client Liaison" },
+];
+
+const TeamShowcase = () => (
+  <section className="py-16">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Our Leadership Team</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {team.map((member, i) => (
+          <div key={i} className="bg-white border rounded-xl p-6 shadow text-center">
+            <h3 className="text-lg font-semibold text-accent mb-1">{member.name}</h3>
+            <p className="text-sm text-gray-600">{member.role}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default TeamShowcase;

--- a/layouts/staffing/JobList.js
+++ b/layouts/staffing/JobList.js
@@ -1,0 +1,28 @@
+"use client";
+
+const jobs = [
+  { title: "Registered Nurse", location: "London", type: "Full Time" },
+  { title: "Healthcare Assistant", location: "Birmingham", type: "Part Time" },
+  { title: "Support Worker", location: "Manchester", type: "Temporary" },
+];
+
+const JobList = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Current Vacancies</h2>
+      <div className="space-y-4">
+        {jobs.map((job, i) => (
+          <div key={i} className="flex flex-col md:flex-row justify-between items-center bg-white border rounded-xl p-6 shadow">
+            <div>
+              <h3 className="font-semibold text-accent">{job.title}</h3>
+              <p className="text-sm text-gray-600">{job.location} – {job.type}</p>
+            </div>
+            <a href="#" className="mt-3 md:mt-0 inline-block bg-primary text-white px-5 py-2 rounded-full text-sm font-semibold hover:bg-opacity-90">Apply</a>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default JobList;

--- a/layouts/staffing/JobsBanner.js
+++ b/layouts/staffing/JobsBanner.js
@@ -1,0 +1,12 @@
+"use client";
+
+const JobsBanner = () => (
+  <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
+    <div className="container py-20 text-center">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">Available Jobs</h1>
+      <p className="max-w-2xl mx-auto text-lg">Browse the latest opportunities with our clients.</p>
+    </div>
+  </section>
+);
+
+export default JobsBanner;


### PR DESCRIPTION
## Summary
- create About, Jobs, and Contact components
- build staffing pages using partials
- share unified contact page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686974d24e108333b5867bc952c133fb