### PR TITLE
Add Domiciliary service pages and components

### DIFF
--- a/app/domiciliary/about-us/page.js
+++ b/app/domiciliary/about-us/page.js
@@ -1,8 +1,13 @@
+import AboutBanner from "@layouts/domiciliary/About/Banner";
+import MissionValues from "@layouts/domiciliary/About/MissionValues";
+import TeamShowcase from "@layouts/domiciliary/About/TeamShowcase";
+
 const AboutUs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">About Us</h1>
-    <p>Information about our domiciliary services.</p>
-  </section>
+  <>
+    <AboutBanner />
+    <MissionValues />
+    <TeamShowcase />
+  </>
 );
 
 export default AboutUs;

--- a/app/domiciliary/available-jobs/page.js
+++ b/app/domiciliary/available-jobs/page.js
@@ -1,8 +1,11 @@
+import JobsBanner from "@layouts/domiciliary/JobsBanner";
+import JobList from "@layouts/domiciliary/JobList";
+
 const AvailableJobs = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Available Jobs</h1>
-    <p>Current job openings within our domiciliary team.</p>
-  </section>
+  <>
+    <JobsBanner />
+    <JobList />
+  </>
 );
 
 export default AvailableJobs;

--- a/app/domiciliary/care-services/page.js
+++ b/app/domiciliary/care-services/page.js
@@ -1,8 +1,15 @@
+import DomiciliaryBanner from "@layouts/domiciliary/Banner";
+import ServiceOptions from "@layouts/domiciliary/Options";
+import ServiceScopes from "@layouts/domiciliary/Scopes";
+import ServiceDescription from "@layouts/domiciliary/Description";
+
 const CareServices = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">Care Services</h1>
-    <p>Overview of the care services we provide.</p>
-  </section>
+  <>
+    <DomiciliaryBanner />
+    <ServiceOptions />
+    <ServiceScopes />
+    <ServiceDescription />
+  </>
 );
 
 export default CareServices;

--- a/app/domiciliary/how-we-work/page.js
+++ b/app/domiciliary/how-we-work/page.js
@@ -1,8 +1,15 @@
+import HowWeWorkBanner from "@layouts/how-we-work/Banner";
+import WorkSteps from "@layouts/how-we-work/WorkSteps";
+import HelpCards from "@layouts/how-we-work/HelpCards";
+import ContactUsBanner from "@layouts/how-we-work/ContactUsBanner";
+
 const HowWeWork = () => (
-  <section className="container py-16">
-    <h1 className="text-3xl font-bold mb-4">How We Work</h1>
-    <p>Learn about our approach to domiciliary care.</p>
-  </section>
+  <>
+    <HowWeWorkBanner />
+    <WorkSteps />
+    <HelpCards />
+    <ContactUsBanner />
+  </>
 );
 
 export default HowWeWork;

--- a/layouts/domiciliary/About/Banner.js
+++ b/layouts/domiciliary/About/Banner.js
@@ -1,0 +1,14 @@
+"use client";
+
+const AboutBanner = () => (
+  <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
+    <div className="container py-20 text-center">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">About Us</h1>
+      <p className="max-w-2xl mx-auto text-lg">
+        Caring for people in the comfort of their own homes is at the heart of everything we do.
+      </p>
+    </div>
+  </section>
+);
+
+export default AboutBanner;

--- a/layouts/domiciliary/About/MissionValues.js
+++ b/layouts/domiciliary/About/MissionValues.js
@@ -1,0 +1,31 @@
+"use client";
+
+const MissionValues = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container grid md:grid-cols-2 gap-10 items-center">
+      <div>
+        <h2 className="text-3xl font-bold text-primary mb-4">Our Mission</h2>
+        <p className="text-gray-700 mb-4">
+          To help people live independently at home by providing compassionate and professional care services.
+        </p>
+        <p className="text-gray-700">Respect, dignity and quality underpin every aspect of our support.</p>
+      </div>
+      <div className="space-y-4">
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Personalised Care</h3>
+          <p className="text-sm text-gray-600">We tailor care plans around each individual's needs.</p>
+        </div>
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Trusted Carers</h3>
+          <p className="text-sm text-gray-600">All staff are fully trained and background checked.</p>
+        </div>
+        <div className="p-6 bg-white border rounded-xl shadow">
+          <h3 className="font-semibold text-accent mb-1">Ongoing Support</h3>
+          <p className="text-sm text-gray-600">We communicate regularly to ensure happiness and wellbeing.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default MissionValues;

--- a/layouts/domiciliary/About/TeamShowcase.js
+++ b/layouts/domiciliary/About/TeamShowcase.js
@@ -1,0 +1,25 @@
+"use client";
+
+const team = [
+  { name: "Emily Carter", role: "Registered Manager" },
+  { name: "Daniel Green", role: "Care Coordinator" },
+  { name: "Lucy Smith", role: "Client Support" },
+];
+
+const TeamShowcase = () => (
+  <section className="py-16">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Our Leadership Team</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {team.map((member, i) => (
+          <div key={i} className="bg-white border rounded-xl p-6 shadow text-center">
+            <h3 className="text-lg font-semibold text-accent mb-1">{member.name}</h3>
+            <p className="text-sm text-gray-600">{member.role}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default TeamShowcase;

--- a/layouts/domiciliary/Banner.js
+++ b/layouts/domiciliary/Banner.js
@@ -1,0 +1,60 @@
+"use client";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+import SwiperCore, { Autoplay, Pagination } from "swiper";
+import "swiper/css";
+import "swiper/css/pagination";
+import Image from "next/image";
+
+SwiperCore.use([Autoplay, Pagination]);
+
+const slides = [
+  {
+    title: "Quality Home Care",
+    text: "Empowering you to live independently with support tailored to your lifestyle.",
+  },
+  {
+    title: "Reliable Carers",
+    text: "Our compassionate team is on hand whenever you need a helping hand.",
+  },
+  {
+    title: "Peace of Mind",
+    text: "Experienced professionals ensuring comfort and safety at home.",
+  },
+];
+
+const DomiciliaryBanner = () => {
+  return (
+    <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] overflow-hidden">
+      <div className="absolute top-0 left-0 w-full h-full z-0 bg-gradient-to-r from-[#2e103d]/40 via-transparent to-transparent pointer-events-none" />
+      <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-32 flex flex-col-reverse lg:flex-row items-center justify-between relative z-20 gap-12">
+        {/* Left Text Carousel */}
+        <div className="w-full lg:w-1/2 animate-fadeLeftSlow">
+          <Swiper modules={[Autoplay, Pagination]} autoplay={{ delay: 4000, disableOnInteraction: false }} pagination={{ clickable: true }} loop>
+            {slides.map((slide, i) => (
+              <SwiperSlide key={i} className="text-white py-4">
+                <h1 className="text-4xl md:text-5xl font-extrabold mb-4 bg-clip-text text-transparent" style={{ backgroundImage: "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)" }}>
+                  {slide.title}
+                </h1>
+                <p className="text-lg max-w-xl">{slide.text}</p>
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        </div>
+        {/* Right Image */}
+        <div className="w-full max-w-[680px] h-auto">
+          <div className="aspect-video h-full rounded-2xl shadow-xl overflow-hidden border border-gray-200 bg-white">
+            <Image src="/images/banner-caregiving/hero1.jpg" alt="Domiciliary banner" width={900} height={720} className="w-full h-full object-cover" />
+          </div>
+        </div>
+      </div>
+      <div className="absolute bottom-0 left-0 right-0 z-10">
+        <svg viewBox="0 0 1440 120" className="w-full h-[100px] lg:h-[160px] transform scale-x-[-1]" preserveAspectRatio="none">
+          <path fill="#431c52" d="M0,32L60,48C120,64,240,96,360,96C480,96,600,64,720,64C840,64,960,96,1080,106.7C1200,117,1320,107,1380,101.3L1440,96L1440,120L1380,120C1320,120,1200,120,1080,120C960,120,840,120,720,120C600,120,480,120,360,120C240,120,120,120,60,120L0,120Z" />
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default DomiciliaryBanner;

--- a/layouts/domiciliary/Description.js
+++ b/layouts/domiciliary/Description.js
@@ -1,0 +1,33 @@
+"use client";
+
+import Image from "next/image";
+
+const ServiceDescription = ({
+  title = "Why Choose Our Domiciliary Care",
+  description = "We pride ourselves on delivering high quality support that allows you or your loved ones to remain comfortable at home.",
+  points = [
+    "Flexible visits from a few hours to full live-in care",
+    "Caring professionals trained to the highest standards",
+    "Regular reviews to adapt services as needs change",
+  ],
+  imageSrc = "/images/banner-caregiving/care-help-2.jpg",
+}) => (
+  <section className="py-16 bg-theme-light">
+    <div className="container grid md:grid-cols-2 gap-8 items-center">
+      <div className="order-2 md:order-1">
+        <Image src={imageSrc} alt={title} width={600} height={400} className="rounded-xl w-full h-auto object-cover border" />
+      </div>
+      <div className="order-1 md:order-2">
+        <h2 className="text-3xl font-bold text-primary mb-4">{title}</h2>
+        <p className="text-gray-700 mb-4">{description}</p>
+        <ul className="list-disc pl-5 space-y-1 text-gray-700 text-sm">
+          {points.map((item, i) => (
+            <li key={i}>{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceDescription;

--- a/layouts/domiciliary/JobList.js
+++ b/layouts/domiciliary/JobList.js
@@ -1,0 +1,31 @@
+"use client";
+
+const jobs = [
+  { title: "Live-in Carer", location: "London", type: "Full Time" },
+  { title: "Care Assistant", location: "Leeds", type: "Part Time" },
+  { title: "Night Support Worker", location: "Bristol", type: "Temporary" },
+];
+
+const JobList = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Current Vacancies</h2>
+      <div className="space-y-4">
+        {jobs.map((job, i) => (
+          <div
+            key={i}
+            className="flex flex-col md:flex-row justify-between items-center bg-white border rounded-xl p-6 shadow"
+          >
+            <div>
+              <h3 className="font-semibold text-accent">{job.title}</h3>
+              <p className="text-sm text-gray-600">{job.location} – {job.type}</p>
+            </div>
+            <a href="#" className="mt-3 md:mt-0 inline-block bg-primary text-white px-5 py-2 rounded-full text-sm font-semibold hover:bg-opacity-90">Apply</a>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default JobList;

--- a/layouts/domiciliary/JobsBanner.js
+++ b/layouts/domiciliary/JobsBanner.js
@@ -1,0 +1,12 @@
+"use client";
+
+const JobsBanner = () => (
+  <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
+    <div className="container py-20 text-center">
+      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">Available Jobs</h1>
+      <p className="max-w-2xl mx-auto text-lg">Explore career opportunities in domiciliary care.</p>
+    </div>
+  </section>
+);
+
+export default JobsBanner;

--- a/layouts/domiciliary/Options.js
+++ b/layouts/domiciliary/Options.js
@@ -1,0 +1,43 @@
+"use client";
+
+import { MdFavorite, MdOutlineHome, MdAccessibility } from "react-icons/md";
+
+const options = [
+  {
+    icon: <MdAccessibility size={40} className="text-accent" />,
+    title: "Personal Care",
+    text: "Assistance with daily routines such as washing, dressing and mobility.",
+  },
+  {
+    icon: <MdOutlineHome size={40} className="text-accent" />,
+    title: "Household Help",
+    text: "Support with shopping, meal preparation and light housework.",
+  },
+  {
+    icon: <MdFavorite size={40} className="text-accent" />,
+    title: "Companionship",
+    text: "Friendly carers to provide company and social interaction.",
+  },
+];
+
+const ServiceOptions = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Our Services</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {options.map((item, i) => (
+          <div
+            key={i}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow hover:shadow-lg transition"
+          >
+            <div className="mb-4 flex justify-center">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{item.title}</h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceOptions;

--- a/layouts/domiciliary/Scopes.js
+++ b/layouts/domiciliary/Scopes.js
@@ -1,0 +1,43 @@
+"use client";
+
+import { MdLocalHospital, MdOutlineVolunteerActivism, MdElderly } from "react-icons/md";
+
+const scopes = [
+  {
+    icon: <MdElderly size={40} className="text-accent" />,
+    title: "Elderly Support",
+    text: "Helping older adults remain safe and comfortable at home.",
+  },
+  {
+    icon: <MdOutlineVolunteerActivism size={40} className="text-accent" />,
+    title: "Respite Services",
+    text: "Short-term care allowing family members to take a break.",
+  },
+  {
+    icon: <MdLocalHospital size={40} className="text-accent" />,
+    title: "Specialist Care",
+    text: "Trained carers experienced with complex medical conditions.",
+  },
+];
+
+const ServiceScopes = () => (
+  <section className="py-16">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Care Areas</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {scopes.map((item, i) => (
+          <div
+            key={i}
+            className="border border-gray-200 rounded-xl p-6 text-center bg-white shadow hover:shadow-lg transition"
+          >
+            <div className="flex justify-center mb-4">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{item.title}</h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceScopes;


### PR DESCRIPTION
## Summary
- implement dedicated Domiciliary pages
- create Domiciliary components for banners, descriptions and jobs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a3b6b6cc88333be62ffe0fc195c62