### PR TITLE
Add custom Care Services page

### DIFF
--- a/app/staffing/care-services/page.js
+++ b/app/staffing/care-services/page.js
@@ -1,15 +1,16 @@
-import StaffingBanner from "@layouts/staffing/Banner";
-import StaffingOptions from "@layouts/staffing/Options";
-import ServiceScopes from "@layouts/staffing/Scopes";
-import ServiceDescription from "@layouts/staffing/Description";
-import WhatWeProvide from "@layouts/staffing/WhatWeProvide";
+import Hero from "@layouts/staffing/CareServices/Hero";
+import ServiceCards from "@layouts/staffing/CareServices/ServiceCards";
+import ServiceProcess from "@layouts/staffing/CareServices/ServiceProcess";
+import WhyChooseUs from "@layouts/staffing/CareServices/WhyChooseUs";
+import ContactBanner from "@layouts/staffing/CareServices/ContactBanner";
 
 const CareServices = () => (
   <>
-    <StaffingBanner />
-    <StaffingOptions />
-    <WhatWeProvide />
-    <ServiceDescription />
+    <Hero />
+    <ServiceCards />
+    <ServiceProcess />
+    <WhyChooseUs />
+    <ContactBanner />
   </>
 );
 

--- a/layouts/staffing/CareServices/ContactBanner.js
+++ b/layouts/staffing/CareServices/ContactBanner.js
@@ -1,0 +1,20 @@
+"use client";
+
+import Link from "next/link";
+
+const ContactBanner = () => (
+  <section className="py-12 bg-gradient-to-r from-[#431c52] via-[#6a2c70] to-[#f4b860] text-center text-white">
+    <h2 className="text-2xl md:text-3xl font-semibold mb-4">Need Caring Professionals?</h2>
+    <p className="mb-6 max-w-xl mx-auto">
+      Get in touch with our friendly team today and discover how Heart & Haven Care can support your organisation.
+    </p>
+    <Link
+      href="/contact"
+      className="inline-block bg-white text-[#431c52] font-semibold px-6 py-3 rounded-full shadow hover:opacity-90 transition"
+    >
+      Contact Us
+    </Link>
+  </section>
+);
+
+export default ContactBanner;

--- a/layouts/staffing/CareServices/Hero.js
+++ b/layouts/staffing/CareServices/Hero.js
@@ -1,0 +1,30 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+const Hero = () => (
+  <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] overflow-hidden">
+    <div className="max-w-screen-xl mx-auto px-6 lg:px-8 py-24 flex flex-col lg:flex-row items-center gap-12 relative z-20">
+      <div className="w-full lg:w-1/2 text-center lg:text-left animate-fadeLeftSlow">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-white">Professional Staffing Services</h1>
+        <p className="mt-4 text-lg text-white max-w-xl mx-auto lg:mx-0">
+          Heart & Haven Care supplies compassionate and reliable professionals across hospitals, care homes and community services.
+        </p>
+        <Link
+          href="/contact"
+          className="inline-block mt-6 border-2 border-white text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-white hover:text-accent transition"
+        >
+          Request Staff Today
+        </Link>
+      </div>
+      <div className="w-full lg:w-1/2 h-64 md:h-80 relative">
+        <div className="absolute inset-0 rounded-2xl shadow-xl overflow-hidden border border-gray-200">
+          <Image src="/images/banner-caregiving/hero2.jpg" alt="Staffing" fill className="object-cover" priority />
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default Hero;

--- a/layouts/staffing/CareServices/ServiceCards.js
+++ b/layouts/staffing/CareServices/ServiceCards.js
@@ -1,0 +1,43 @@
+"use client";
+
+import { MdLocalHospital, MdElderly, MdCleaningServices } from "react-icons/md";
+
+const services = [
+  {
+    icon: <MdLocalHospital size={36} className="text-primary" />,
+    title: "Nurses & HCAs",
+    text: "Qualified nurses and healthcare assistants available for temporary or permanent placements.",
+  },
+  {
+    icon: <MdElderly size={36} className="text-primary" />,
+    title: "Support Workers",
+    text: "Experienced carers for learning disability, mental health and community support.",
+  },
+  {
+    icon: <MdCleaningServices size={36} className="text-primary" />,
+    title: "Domestic Staff",
+    text: "Reliable ancillary staff including cooks and cleaners to keep services running smoothly.",
+  },
+];
+
+const ServiceCards = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-12">Our Staffing Options</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {services.map((item, index) => (
+          <div
+            key={index}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow hover:shadow-lg transition"
+          >
+            <div className="mb-4 flex justify-center">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{item.title}</h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceCards;

--- a/layouts/staffing/CareServices/ServiceProcess.js
+++ b/layouts/staffing/CareServices/ServiceProcess.js
@@ -1,0 +1,40 @@
+"use client";
+
+const steps = [
+  {
+    title: "Tell Us Your Needs",
+    text: "Contact our team and outline the roles and skills you're looking for.",
+  },
+  {
+    title: "We Source Candidates",
+    text: "Our extensive network allows us to quickly match the best professionals to your requirements.",
+  },
+  {
+    title: "Start Working",
+    text: "We arrange introductions and handle compliance checks so staff can begin without delay.",
+  },
+];
+
+const ServiceProcess = () => (
+  <section className="py-16">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-12">How It Works</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {steps.map((step, i) => (
+          <div
+            key={i}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow-md hover:shadow-lg transition"
+          >
+            <div className="w-12 h-12 mx-auto mb-4 text-lg font-bold flex items-center justify-center rounded-full bg-accent text-white">
+              {i + 1}
+            </div>
+            <h3 className="font-semibold text-accent mb-2">{step.title}</h3>
+            <p className="text-sm text-gray-600">{step.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceProcess;

--- a/layouts/staffing/CareServices/WhyChooseUs.js
+++ b/layouts/staffing/CareServices/WhyChooseUs.js
@@ -1,0 +1,43 @@
+"use client";
+
+import { MdVerifiedUser, MdSupportAgent, MdAccessTime } from "react-icons/md";
+
+const reasons = [
+  {
+    icon: <MdVerifiedUser size={36} className="text-primary" />,
+    title: "Thorough Vetting",
+    text: "All personnel undergo DBS and reference checks for complete peace of mind.",
+  },
+  {
+    icon: <MdSupportAgent size={36} className="text-primary" />,
+    title: "Dedicated Support",
+    text: "Our consultants are on hand 24/7 to respond to urgent requests and queries.",
+  },
+  {
+    icon: <MdAccessTime size={36} className="text-primary" />,
+    title: "Fast Response",
+    text: "We maintain a wide pool of available staff allowing quick placements when you need them most.",
+  },
+];
+
+const WhyChooseUs = () => (
+  <section className="py-16 bg-[#f9f7fc]">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-12">Why Choose Heart & Haven</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {reasons.map((reason, index) => (
+          <div
+            key={index}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow hover:shadow-lg transition"
+          >
+            <div className="mb-4 flex justify-center">{reason.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{reason.title}</h3>
+            <p className="text-sm text-gray-600">{reason.text}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default WhyChooseUs;


### PR DESCRIPTION
## Summary
- build a custom `staffing/care-services` page using themed components
- add new components for hero, service cards, process steps, reasons and contact banner

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_686a3d2a0af88333875dee2ff91f13b4