### PR TITLE
Add domiciliary services list

### DIFF
--- a/app/domiciliary/page.js
+++ b/app/domiciliary/page.js
@@ -2,7 +2,7 @@ import config from "@config/config.json";
 
 import HomeBanner from "@layouts/partials/HomeBanner";
 import HomeFeatures from "@layouts/partials/HomeFeatures";
-import Services from "@layouts/partials/Services";
+import Services from "@layouts/domiciliary-care-home/Services";
 import { getListPage, getRegularPage } from "../../lib/contentParser";
 import banner from "@/content/home/banner.json";
 import DomiciliaryBanner from "@layouts/domiciliary-care-home/Banner";
@@ -14,7 +14,7 @@ const Domiciliary = async () => {
   const contactPage = await getRegularPage("contact");
 
   const { frontmatter } = homePage;
-  const { feature, services, workflow, call_to_action } = frontmatter;
+  const { feature } = frontmatter;
   const { title } = config.site;
 
   return (
@@ -22,7 +22,7 @@ const Domiciliary = async () => {
       {/* Banner */}
       <HomeBanner banner={banner} />
       {/* services */}
-      <Services services={services} />
+      <Services />
       <DomiciliaryPerks feature={feature} />
       <StaffingApart />
       <Contact data={contactPage} />

--- a/layouts/domiciliary-care-home/Services.js
+++ b/layouts/domiciliary-care-home/Services.js
@@ -1,0 +1,61 @@
+"use client";
+import Link from "next/link";
+import {
+  MdAccessTime,
+  MdHome,
+  MdOutlinePsychology,
+  MdHotel,
+} from "react-icons/md";
+
+const services = [
+  {
+    icon: <MdAccessTime size={40} className="text-accent" />,
+    title: "Hourly Visiting",
+    text: "Flexible visits providing help with day-to-day tasks when you need it.",
+  },
+  {
+    icon: <MdHome size={40} className="text-accent" />,
+    title: "Live-In Care",
+    text: "24/7 support from a carer living with you at home.",
+  },
+  {
+    icon: <MdOutlinePsychology size={40} className="text-accent" />,
+    title: "Dementia Care",
+    text: "Specialist assistance allowing those with dementia to stay at home.",
+  },
+  {
+    icon: <MdHotel size={40} className="text-accent" />,
+    title: "Respite Care",
+    text: "Short-term care giving family and friends a well-earned break.",
+  },
+];
+
+const DomiciliaryHomeServices = () => (
+  <section className="py-16 bg-theme-light">
+    <div className="container">
+      <h2 className="text-center text-3xl font-bold text-primary mb-8">Our Domiciliary Services</h2>
+      <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-4">
+        {services.map((item, i) => (
+          <div
+            key={i}
+            className="bg-white border border-gray-200 rounded-xl p-6 text-center shadow hover:shadow-lg transition"
+          >
+            <div className="mb-4 flex justify-center">{item.icon}</div>
+            <h3 className="text-lg font-semibold text-accent mb-2">{item.title}</h3>
+            <p className="text-sm text-gray-600">{item.text}</p>
+          </div>
+        ))}
+      </div>
+      <div className="text-center mt-8">
+        <Link
+          href="/domiciliary/care-services"
+          className="inline-block bg-primary text-white px-6 py-3 rounded-full font-semibold hover:bg-opacity-90 transition"
+        >
+          All Services
+        </Link>
+      </div>
+    </div>
+  </section>
+);
+
+export default DomiciliaryHomeServices;

--- a/layouts/domiciliary/Options.js
+++ b/layouts/domiciliary/Options.js
@@ -1,22 +1,57 @@
 "use client";
 
-import { MdFavorite, MdOutlineHome, MdAccessibility } from "react-icons/md";
+import {
+  MdOutlineHome,
+  MdAccessibility,
+  MdHolidayVillage,
+  MdLocalHospital,
+  MdNightlight,
+  MdPeople,
+  MdMedicalServices,
+  MdHotel,
+  MdAccessibilityNew,
+} from "react-icons/md";
 
 const options = [
   {
-    icon: <MdAccessibility size={40} className="text-accent" />,
-    title: "Personal Care",
-    text: "Assistance with daily routines such as washing, dressing and mobility.",
+    icon: <MdHolidayVillage size={40} className="text-accent" />,
+    title: "Holiday Care",
+    text: "Short-term support while family carers are away on holiday.",
+  },
+  {
+    icon: <MdLocalHospital size={40} className="text-accent" />,
+    title: "Hospital to Home",
+    text: "Helping you settle back home safely after a hospital stay.",
   },
   {
     icon: <MdOutlineHome size={40} className="text-accent" />,
-    title: "Household Help",
-    text: "Support with shopping, meal preparation and light housework.",
+    title: "Live in Care",
+    text: "Full-time care in your own home giving constant reassurance.",
   },
   {
-    icon: <MdFavorite size={40} className="text-accent" />,
-    title: "Companionship",
-    text: "Friendly carers to provide company and social interaction.",
+    icon: <MdNightlight size={40} className="text-accent" />,
+    title: "Night Care",
+    text: "Overnight assistance for peace of mind and uninterrupted rest.",
+  },
+  {
+    icon: <MdAccessibilityNew size={40} className="text-accent" />,
+    title: "Personal Care",
+    text: "Support with washing, dressing and other daily routines.",
+  },
+  {
+    icon: <MdHotel size={40} className="text-accent" />,
+    title: "Respite Care",
+    text: "Temporary care giving family members time to recharge.",
+  },
+  {
+    icon: <MdMedicalServices size={40} className="text-accent" />,
+    title: "Specialist Care",
+    text: "Bespoke services for complex medical or disability needs.",
+  },
+  {
+    icon: <MdPeople size={40} className="text-accent" />,
+    title: "Social Companionship",
+    text: "Friendly company and help getting out and about.",
   },
 ];
 
@@ -24,7 +59,7 @@ const ServiceOptions = () => (
   <section className="py-16 bg-theme-light">
     <div className="container">
       <h2 className="text-center text-3xl font-bold text-primary mb-8">Our Services</h2>
-      <div className="grid gap-8 md:grid-cols-3">
+      <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         {options.map((item, i) => (
           <div
             key={i}


### PR DESCRIPTION
## Summary
- show bespoke service cards on the domiciliary landing page
- list full domiciliary service offerings on the services page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879e4ba41808333bc4a13533cfcbad5