### PR TITLE
Add card-based workflow to domiciliary page

### DIFF
--- a/app/domiciliary/how-we-work/page.js
+++ b/app/domiciliary/how-we-work/page.js
@@ -1,20 +1,14 @@
-import PageHero from "@layouts/partials/PageHero";
-import Workflow from "@layouts/partials/Workflow";
-import { getListPage } from "@lib/contentParser";
-
-const HowWeWorkPage = async () => {
-  const home = await getListPage("content/_index.md");
-  const { workflow } = home.frontmatter;
-  return (
-    <>
-      <PageHero
-        title="How We Work"
-        subtitle="Our process ensures quality care"
-        image="/images/banner-caregiving/hero3.jpg"
-      />
-      <Workflow workflow={workflow} />
-    </>
-  );
-};
+import HowWeWorkBanner from "@layouts/how-we-work/Banner";
+import WorkSteps from "@layouts/how-we-work/WorkSteps";
+import HelpCards from "@layouts/how-we-work/HelpCards";
+import ContactUsBanner from "@layouts/how-we-work/ContactUsBanner";
+const HowWeWorkPage = () => (
+  <>
+    <HowWeWorkBanner />
+    <WorkSteps />
+    <HelpCards />
+    <ContactUsBanner />
+  </>
+);
 
 export default HowWeWorkPage;


### PR DESCRIPTION
## Summary
- update `domiciliary/how-we-work` page to use workflow cards and banners

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879e5c90eb083338e6e7ceb87384a60