### PR TITLE
Update domiciliary contact page layout

### DIFF
--- a/app/domiciliary/contact-us/page.js
+++ b/app/domiciliary/contact-us/page.js
@@ -10,6 +10,7 @@ const ContactUsPage = async () => {
         title="Contact Us"
         subtitle="We are here to help"
         image="/images/banner-caregiving/hero2.jpg"
+        small
       />
       <Contact data={data} />
     </>

--- a/layouts/Contact.js
+++ b/layouts/Contact.js
@@ -9,15 +9,26 @@ const Contact = ({ data }) => {
   return (
     <section className="section">
       <div className="container">
-        {markdownify(title, "h1", "text-center font-normal")}
-        <div className="section row pb-0">
-          <div className="col-12 md:col-6 lg:col-7">
+        {markdownify(title, "h1", "text-center font-normal mb-8")}
+        <div className="grid md:grid-cols-2 gap-10 items-start">
+          <div className="order-2 md:order-1 content">
+            {markdownify(info.title, "h4")}
+            {markdownify(info.description, "p", "mt-4")}
+            <ul className="contact-list mt-5 space-y-2">
+              {info.contacts.map((contact, index) => (
+                <li key={index}>
+                  {markdownify(contact, "strong", "text-dark")}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="order-1 md:order-2">
             <form
-              className="contact-form"
+              className="space-y-4"
               method="POST"
               action={contact_form_action}
             >
-              <div className="mb-3">
+              <div className="grid md:grid-cols-2 gap-4">
                 <input
                   className="form-input w-full rounded"
                   name="name"
@@ -25,47 +36,35 @@ const Contact = ({ data }) => {
                   placeholder="Name"
                   required
                 />
-              </div>
-              <div className="mb-3">
                 <input
                   className="form-input w-full rounded"
-                  name="email"
-                  type="email"
-                  placeholder="Your email"
-                  required
-                />
-              </div>
-              <div className="mb-3">
-                <input
-                  className="form-input w-full rounded"
-                  name="subject"
+                  name="phone"
                   type="text"
-                  placeholder="Subject"
-                  required
+                  placeholder="Phone"
                 />
               </div>
-              <div className="mb-3">
-                <textarea
-                  className="form-textarea w-full rounded-md"
-                  rows="7"
-                  placeholder="Your message"
-                />
-              </div>
-              <button type="submit" className="btn btn-primary">
-                Send Now
+              <input
+                className="form-input w-full rounded"
+                name="email"
+                type="email"
+                placeholder="Email"
+                required
+              />
+              <input
+                className="form-input w-full rounded"
+                name="subject"
+                type="text"
+                placeholder="Subject"
+              />
+              <textarea
+                className="form-textarea w-full rounded-md"
+                rows="6"
+                placeholder="Message"
+              />
+              <button type="submit" className="btn btn-primary w-full">
+                Send Message
               </button>
             </form>
-          </div>
-          <div className="content col-12 md:col-6 lg:col-5">
-            {markdownify(info.title, "h4")}
-            {markdownify(info.description, "p", "mt-4")}
-            <ul className="contact-list mt-5">
-              {info.contacts.map((contact, index) => (
-                <li key={index}>
-                  {markdownify(contact, "strong", "text-dark")}
-                </li>
-              ))}
-            </ul>
           </div>
         </div>
       </div>

--- a/layouts/partials/PageHero.js
+++ b/layouts/partials/PageHero.js
@@ -1,8 +1,8 @@
 "use client";
 import Image from "next/image";
 
-const PageHero = ({ title, subtitle, image }) => (
-  <section className="py-20 bg-soft-care-gradient">
+const PageHero = ({ title, subtitle, image, small = false }) => (
+  <section className={`${small ? "py-12" : "py-20"} bg-soft-care-gradient`}>
     <div className="container mx-auto grid md:grid-cols-2 gap-8 items-center">
       <div>
         <h1 className="text-4xl font-bold text-primary mb-4">{title}</h1>
@@ -13,8 +13,8 @@ const PageHero = ({ title, subtitle, image }) => (
           <Image
             src={image}
             alt={title}
-            width={600}
-            height={400}
+            width={small ? 400 : 600}
+            height={small ? 300 : 400}
             className="object-cover w-full h-auto"
           />
         </div>


### PR DESCRIPTION
## Summary
- tweak `PageHero` component to support a small layout
- reduce hero size on `domiciliary/contact-us` page
- redesign contact form with phone field

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879e62eeadc8333b820d2d57d758269