### PR TITLE
Fix mobile menu and align slider text

### DIFF
--- a/layouts/partials/HomeBannerMain.js
+++ b/layouts/partials/HomeBannerMain.js
@@ -44,7 +44,7 @@ const HomeBannerMain = () => {
         {slides.map((slide, index) => (
           <SwiperSlide key={index}>
             <div
-              className="w-full h-full relative flex items-center justify-center text-center px-4 md:px-8 bg-cover bg-center"
+              className="w-full h-full relative flex items-center justify-start text-left px-4 md:px-12 bg-cover bg-center"
               style={{
                 backgroundImage: `url(${slide.image})`,
               }}
@@ -53,7 +53,7 @@ const HomeBannerMain = () => {
               <div className="absolute inset-0 z-0 bg-gradient-to-r from-[#431c52cc] via-[#6a2c70cc] to-[#f4b860cc]" />
 
               {/* Content */}
-              <div className="z-10 max-w-3xl text-white">
+              <div className="z-10 max-w-3xl text-white text-left">
                 <h1 className="text-3xl md:text-5xl font-bold mb-4 text-white">
                   {slide.title}
                 </h1>

--- a/layouts/partials/SimpleHeader.js
+++ b/layouts/partials/SimpleHeader.js
@@ -3,19 +3,29 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import { FaPhoneAlt, FaFacebookF, FaLinkedinIn } from "react-icons/fa";
 import config from "@config/config.json";
 import menu from "@config/menu.json";
 
 const SimpleHeader = () => {
   const pathname = usePathname();
+  const [navOpen, setNavOpen] = useState(false);
   const { main } = menu;
   const { base_url, logo, title } = config.site;
+
+  const serviceName = pathname.startsWith("/domiciliary")
+    ? "Domiciliary Care"
+    : pathname.startsWith("/staffing")
+    ? "Temporary Staffing"
+    : pathname.startsWith("/supported-living")
+    ? "Supported Living"
+    : "";
 
   return (
     <header className="bg-white shadow border-b border-[#e5e5f7]">
       <div className="max-w-7xl mx-auto px-4 md:px-8">
-        <div className="flex items-center justify-between py-6 md:py-8">
+        <div className="flex items-center justify-between py-4">
           {/* Left: Logo */}
           <Link href={base_url} className="flex items-center">
             <Image
@@ -23,9 +33,14 @@ const SimpleHeader = () => {
               alt={title}
               width={240}
               height={100}
-              className="object-contain max-h-[100px] w-auto"
+              className="object-contain max-h-[80px] w-auto"
               priority
             />
+            {serviceName && (
+              <span className="ml-2 text-sm font-semibold text-[#5e3ea1]">
+                {serviceName}
+              </span>
+            )}
           </Link>
 
           {/* Center: Navigation */}
@@ -47,6 +62,31 @@ const SimpleHeader = () => {
               ))}
             </ul>
           </nav>
+
+          {/* Mobile menu toggle */}
+          <button
+            className="md:hidden text-[#5e3ea1]"
+            onClick={() => setNavOpen(!navOpen)}
+            aria-label="Toggle menu"
+          >
+            <svg className="w-7 h-7" fill="none" stroke="currentColor">
+              {navOpen ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              )}
+            </svg>
+          </button>
 
           {/* Right: Contact + Social */}
           <div className="hidden md:flex items-center space-x-6 border-l pl-6 border-[#ccc]">
@@ -82,6 +122,27 @@ const SimpleHeader = () => {
             </div>
           </div>
         </div>
+        {navOpen && (
+          <div className="md:hidden pb-4">
+            <ul className="space-y-2 font-medium text-gray-700">
+              {main.map((item, i) => (
+                <li key={i}>
+                  <Link
+                    href={item.url}
+                    onClick={() => setNavOpen(false)}
+                    className={`block px-3 py-2 rounded-md transition ${
+                      pathname === item.url
+                        ? "bg-[#5e3ea1] text-white"
+                        : "hover:text-[#5e3ea1]"
+                    }`}
+                  >
+                    {item.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- add responsive mobile menu
- show service name in simple header
- match header height with service pages
- left align text in the home page slider

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881fd88ba3c8333a99e897232dd116c