### PR TITLE
Refine domiciliary page styling

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -2,11 +2,11 @@
 title: "Contact Us"
 layout: "contact"
 draft: false
-info: 
+info:
   title: Why you should contact us!
   description: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Velit recusandae voluptates doloremque veniam temporibus porro culpa ipsa, nisi soluta minima saepe laboriosam debitis nesciunt.
   contacts:
     - "phone: 01788 422422"
-    - "Mail: [info@bigspring.com](mailto:info@bigspring.com)"
+    - "Mail: [info@heartandhavencare.co.uk](mailto:info@heartandhavencare.co.uk)"
     - "Address: 6A Davy Court, Castle Mound Way, Central Park, Rugby, CV23 0UZ"
 ---

--- a/layouts/domiciliary/About/Banner.js
+++ b/layouts/domiciliary/About/Banner.js
@@ -3,9 +3,18 @@
 const AboutBanner = () => (
   <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
     <div className="container py-20 text-center">
-      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">About Us</h1>
+      <h1
+        className="text-4xl md:text-5xl font-extrabold mb-4 bg-clip-text text-transparent"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)",
+        }}
+      >
+        About Us
+      </h1>
       <p className="max-w-2xl mx-auto text-lg">
-        Caring for people in the comfort of their own homes is at the heart of everything we do.
+        Caring for people in the comfort of their own homes is at the heart of
+        everything we do.
       </p>
     </div>
   </section>

--- a/layouts/domiciliary/Careers/Banner.js
+++ b/layouts/domiciliary/Careers/Banner.js
@@ -3,9 +3,18 @@
 const CareersBanner = () => (
   <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
     <div className="container py-20 text-center">
-      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">Our Careers</h1>
+      <h1
+        className="text-4xl md:text-5xl font-extrabold mb-4 bg-clip-text text-transparent"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)",
+        }}
+      >
+        Our Careers
+      </h1>
       <p className="max-w-2xl mx-auto text-lg">
-        Discover rewarding opportunities and join our exceptional team of carers.
+        Discover rewarding opportunities and join our exceptional team of
+        carers.
       </p>
     </div>
   </section>

--- a/layouts/domiciliary/JobList.js
+++ b/layouts/domiciliary/JobList.js
@@ -14,7 +14,13 @@ const JobList = () => {
   return (
     <section className="py-16 bg-theme-light">
       <div className="container">
-        <h2 className="text-center text-3xl font-bold text-primary mb-8">
+        <h2
+          className="text-center text-3xl font-bold mb-8 bg-clip-text text-transparent"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)",
+          }}
+        >
           Current Vacancies
         </h2>
         <div className="space-y-4">

--- a/layouts/domiciliary/JobsBanner.js
+++ b/layouts/domiciliary/JobsBanner.js
@@ -3,8 +3,18 @@
 const JobsBanner = () => (
   <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
     <div className="container py-20 text-center">
-      <h1 className="text-4xl md:text-5xl font-extrabold mb-4">Available Jobs</h1>
-      <p className="max-w-2xl mx-auto text-lg">Explore career opportunities in domiciliary care.</p>
+      <h1
+        className="text-4xl md:text-5xl font-extrabold mb-4 bg-clip-text text-transparent"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)",
+        }}
+      >
+        Available Jobs
+      </h1>
+      <p className="max-w-2xl mx-auto text-lg">
+        Explore career opportunities in domiciliary care.
+      </p>
     </div>
   </section>
 );

--- a/layouts/partials/PageHero.js
+++ b/layouts/partials/PageHero.js
@@ -2,19 +2,29 @@
 import Image from "next/image";
 
 const PageHero = ({ title, subtitle, image, small = false }) => (
-  <section className={`${small ? "py-12" : "py-20"} bg-soft-care-gradient`}>
+  <section
+    className={`${small ? "py-12" : "py-20"} bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860]`}
+  >
     <div className="container mx-auto grid md:grid-cols-2 gap-8 items-center">
       <div>
-        <h1 className="text-4xl font-bold text-primary mb-4">{title}</h1>
-        {subtitle && <p className="text-lg text-gray-700">{subtitle}</p>}
+        <h1
+          className="text-4xl font-bold mb-4 bg-clip-text text-transparent"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, #9e3ea1, #d46f4d, #f4b860)",
+          }}
+        >
+          {title}
+        </h1>
+        {subtitle && <p className="text-lg text-white">{subtitle}</p>}
       </div>
       {image && (
         <div className="rounded-xl overflow-hidden shadow-lg">
           <Image
             src={image}
             alt={title}
-            width={small ? 400 : 600}
-            height={small ? 300 : 400}
+            width={700}
+            height={500}
             className="object-cover w-full h-auto"
           />
         </div>


### PR DESCRIPTION
## Summary
- apply gradient text style to Domiciliary subpage banners
- align JobList heading with brand gradient
- unify PageHero gradient and image sizing
- update contact information email

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68836ad9b92083339c8eadf2b6c34ba8