### PR TITLE
Update domiciliary contact text and email handling

### DIFF
--- a/app/api/messages/route.js
+++ b/app/api/messages/route.js
@@ -1,14 +1,15 @@
-import { NextResponse } from 'next/server';
-import fs from 'fs/promises';
-import path from 'path';
-import nodemailer from 'nodemailer';
+import { NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import nodemailer from "nodemailer";
+import config from "@config/config.json";
 
-const messagesFile = path.join(process.cwd(), 'data', 'messages.json');
+const messagesFile = path.join(process.cwd(), "data", "messages.json");
 
 async function readMessages() {
   try {
-    const data = await fs.readFile(messagesFile, 'utf8');
-    return JSON.parse(data || '[]');
+    const data = await fs.readFile(messagesFile, "utf8");
+    return JSON.parse(data || "[]");
   } catch {
     return [];
   }
@@ -21,7 +22,7 @@ async function writeMessages(messages) {
 
 async function sendEmail(msg) {
   const transporter = nodemailer.createTransport({
-    service: 'gmail',
+    service: "gmail",
     auth: {
       user: process.env.EMAIL_USER,
       pass: process.env.EMAIL_PASS,
@@ -32,15 +33,16 @@ async function sendEmail(msg) {
     <h2>New Contact Message</h2>
     <p><strong>Name:</strong> ${msg.name}</p>
     <p><strong>Email:</strong> ${msg.email}</p>
-    <p><strong>Phone:</strong> ${msg.phone || ''}</p>
-    <p><strong>Subject:</strong> ${msg.subject || ''}</p>
+    <p><strong>Phone:</strong> ${msg.phone || ""}</p>
+    <p><strong>Subject:</strong> ${msg.subject || ""}</p>
+    <p><strong>Type:</strong> ${msg.type || ""}</p>
     <p>${msg.message}</p>
   `;
 
   await transporter.sendMail({
     from: process.env.EMAIL_USER,
-    to: 'masud.official@gmail.com',
-    subject: msg.subject ? `Contact: ${msg.subject}` : 'Contact Form Message',
+    to: config.params.contact_email,
+    subject: msg.subject ? `Contact: ${msg.subject}` : "Contact Form Message",
     html,
   });
 }
@@ -53,11 +55,12 @@ export async function GET() {
 export async function POST(req) {
   const form = await req.formData();
   const msg = {
-    name: form.get('name') || '',
-    email: form.get('email') || '',
-    phone: form.get('phone') || '',
-    subject: form.get('subject') || '',
-    message: form.get('message') || '',
+    name: form.get("name") || "",
+    email: form.get("email") || "",
+    phone: form.get("phone") || "",
+    subject: form.get("subject") || "",
+    message: form.get("message") || "",
+    type: form.get("type") || "",
     date: new Date().toISOString(),
   };
 
@@ -68,8 +71,8 @@ export async function POST(req) {
   try {
     await sendEmail(msg);
   } catch (err) {
-    console.error('Email failed', err);
+    console.error("Email failed", err);
   }
 
-  return NextResponse.redirect('/thank-you');
+  return NextResponse.redirect("/thank-you");
 }

--- a/app/domiciliary/contact-us/page.js
+++ b/app/domiciliary/contact-us/page.js
@@ -12,7 +12,7 @@ const ContactUsPage = async () => {
         image="/images/banner-caregiving/hero2.jpg"
         small
       />
-      <Contact data={data} />
+      <Contact data={data} requestType="domiciliary" />
     </>
   );
 };

--- a/config/config.json
+++ b/config/config.json
@@ -23,6 +23,7 @@
 
   "params": {
     "contact_form_action": "/api/messages",
+    "contact_email": "masud.official@gmail.com",
     "tag_manager_id": "",
     "footer_content": "Lorem ipsum dolor sit amet, consectetur elit. Consjat tristique eget amet, tempus eu at cttur.",
     "copyright": "Designed and Developed By [Themefisher](https://themefisher.com/)"

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,12 +1,16 @@
 ---
-title: "Contact Us"
+title: "Contact Us – Domiciliary Care"
 layout: "contact"
 draft: false
 info:
-  title: Why you should contact us!
-  description: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Velit recusandae voluptates doloremque veniam temporibus porro culpa ipsa, nisi soluta minima saepe laboriosam debitis nesciunt.
-  contacts:
-    - "phone: 01788 422422"
-    - "Mail: [info@heartandhavencare.co.uk](mailto:info@heartandhavencare.co.uk)"
-    - "Address: 6A Davy Court, Castle Mound Way, Central Park, Rugby, CV23 0UZ"
+  title: Compassionate care, right at your doorstep.
+  description: >-
+    If you or a loved one is looking for reliable, person-centred domiciliary care, we're here to help. Our friendly care team is available to answer your questions, discuss your needs, and guide you through the process of arranging care at home.
+
+    Get in touch with us today to learn more about how we can support you in living safely and independently.
+
+    Or simply fill out the form below and a member of our care coordination team will get back to you promptly.
+
+    Your care. Your way. With Heart & Haven.
+  contacts: []
 ---

--- a/layouts/Contact.js
+++ b/layouts/Contact.js
@@ -1,10 +1,21 @@
 import config from "@config/config.json";
+import social from "@config/social.json";
 import { markdownify } from "@lib/utils/textConverter";
 
-const Contact = ({ data }) => {
+const Contact = ({ data, requestType }) => {
   const { frontmatter } = data;
   const { title, info } = frontmatter;
   const { contact_form_action } = config.params;
+  const { phone, address, email } = social;
+
+  const defaultContacts = [
+    `**\uD83D\uDCCD Address**  \nHeart & Haven Healthcare  \n${address}`,
+    `**\uD83D\uDCDE Phone**  \n${phone}`,
+    `**\uD83D\uDCE7 Email**  \n[${email}](mailto:${email})`,
+    `**\uD83D\uDD50 Office Hours**  \nMonday – Friday: 9:00 AM – 6:00 PM  \nWeekend appointments available by request.`,
+  ];
+  const contacts =
+    info.contacts && info.contacts.length > 0 ? info.contacts : defaultContacts;
 
   return (
     <section className="section">
@@ -15,10 +26,8 @@ const Contact = ({ data }) => {
             {markdownify(info.title, "h4")}
             {markdownify(info.description, "p", "mt-4")}
             <ul className="contact-list mt-5 space-y-2">
-              {info.contacts.map((contact, index) => (
-                <li key={index}>
-                  {markdownify(contact, "strong", "text-dark")}
-                </li>
+              {contacts.map((contact, index) => (
+                <li key={index}>{markdownify(contact, "div", "text-dark")}</li>
               ))}
             </ul>
           </div>
@@ -63,6 +72,9 @@ const Contact = ({ data }) => {
                 placeholder="Message"
                 required
               />
+              {requestType && (
+                <input type="hidden" name="type" value={requestType} />
+              )}
               <button type="submit" className="btn btn-primary w-full">
                 Send Message
               </button>


### PR DESCRIPTION
## Summary
- overhaul domiciliary contact page text
- pull address and email from config in the contact layout
- add hidden input with request type for domiciliary page
- store request type and send emails to address defined in config

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b1320088c8333a2095bc67b9ea1de