### PR TITLE
Update our-careers page layout

### DIFF
--- a/app/domiciliary/our-careers/page.js
+++ b/app/domiciliary/our-careers/page.js
@@ -1,12 +1,16 @@
 import CareersBanner from "@layouts/domiciliary/Careers/Banner";
 import Intro from "@layouts/domiciliary/Careers/Intro";
 import Benefits from "@layouts/domiciliary/Careers/Benefits";
+import JobList from "@layouts/domiciliary/JobList";
+import ContactUsBanner from "@layouts/how-we-work/ContactUsBanner";
 
 const OurCareers = () => (
   <>
     <CareersBanner />
     <Intro />
     <Benefits />
+    <JobList />
+    <ContactUsBanner />
   </>
 );
 


### PR DESCRIPTION
## Summary
- extend `domiciliary/our-careers` page with more content
- add `JobList` and `ContactUsBanner` components so it matches other sections

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688bb1125ee48333a7590480142402d8