### PR TITLE
Add Get Started page

### DIFF
--- a/app/domiciliary/get-started/page.js
+++ b/app/domiciliary/get-started/page.js
@@ -1,0 +1,20 @@
+import PageHero from "@layouts/partials/PageHero";
+import Contact from "@layouts/Contact";
+import { getRegularPage } from "@lib/contentParser";
+
+const GetStartedPage = async () => {
+  const data = await getRegularPage("contact");
+  return (
+    <>
+      <PageHero
+        title="Get Started"
+        subtitle="Let us know how we can help"
+        image="/images/banner-caregiving/hero3.jpg"
+        small
+      />
+      <Contact data={data} requestType="domiciliary-get-started" />
+    </>
+  );
+};
+
+export default GetStartedPage;

--- a/layouts/domiciliary/About/Banner.js
+++ b/layouts/domiciliary/About/Banner.js
@@ -1,4 +1,5 @@
 "use client";
+import Link from "next/link";
 
 const AboutBanner = () => (
   <section className="relative z-10 bg-gradient-to-br from-[#431c52] via-[#6a2c70] to-[#f4b860] text-white">
@@ -23,6 +24,12 @@ const AboutBanner = () => (
         Haven, you’re not just receiving care — you’re gaining a partner who
         genuinely understands and respects your journey.
       </p>
+      <Link
+        href="/domiciliary/get-started"
+        className="inline-block mt-6 border-2 border-white text-white px-6 py-3 rounded-full text-lg font-semibold shadow hover:bg-white hover:text-accent transition"
+      >
+        Get Started
+      </Link>
     </div>
   </section>
 );


### PR DESCRIPTION
## Summary
- add a Get Started button to the Domiciliary About banner
- create `/domiciliary/get-started` page that reuses the Contact form

## Testing
- `npm run lint`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c60da430c8333b96bd59a193e12e7